### PR TITLE
Remove duplicate return button from stock consultation page

### DIFF
--- a/app1.0/gestion_stock/Consultation_emplacement.php
+++ b/app1.0/gestion_stock/Consultation_emplacement.php
@@ -128,9 +128,6 @@ if (!isset($_SESSION['logged_in'])) {
 <?php $baseUrl = '..'; require __DIR__ . '/../partials/top_nav.php'; ?>
 <main class="visualisation-3d" role="main">
   <nav class="return-buttons" aria-label="Navigation retour">
-    <a href="dashboard.php#consulter" class="btn-retour">
-      ← Retour à la liste des stocks
-    </a>
     <a href="consulter_stock.php" class="btn-retour">
       ← Retour à la gestion des stocks
     </a>


### PR DESCRIPTION
## Summary
- remove the redundant top return button from the emplacement consultation view so only the management link remains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd02a7894832aaceded17e31da60a