### PR TITLE
Keep only dashboard return link on emplacement consultation page

### DIFF
--- a/app1.0/gestion_stock/Consultation_emplacement.php
+++ b/app1.0/gestion_stock/Consultation_emplacement.php
@@ -131,9 +131,6 @@ if (!isset($_SESSION['logged_in'])) {
     <a href="dashboard.php#consulter" class="btn-retour">
       ← Retour à la liste des stocks
     </a>
-    <a href="consulter_stock.php" class="btn-retour">
-      ← Retour à la gestion des stocks
-    </a>
   </nav>
   <div id="app" aria-label="Visualisation 3D de l'entrepôt"></div>
   <div class="hint"><b>Contrôles :</b> glisser pour orbiter • molette pour zoomer • clic droit pour déplacer</div>


### PR DESCRIPTION
## Summary
- restore the dashboard return link on the emplacement consultation view while removing the management link so only the top button is gone

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd02a7894832aaceded17e31da60a