### PR TITLE
Ensure non-admin users can return from emplacement consultation

### DIFF
--- a/app1.0/gestion_stock/Consultation_emplacement.php
+++ b/app1.0/gestion_stock/Consultation_emplacement.php
@@ -4,6 +4,17 @@ if (!isset($_SESSION['logged_in'])) {
     header('Location: ../login.php');
     exit();
 }
+
+$lieuxDisponibles = ['Rabat', 'Ouled Saleh'];
+$currentLieu = $_GET['lieu'] ?? $lieuxDisponibles[0];
+if (!in_array($currentLieu, $lieuxDisponibles, true)) {
+    $currentLieu = $lieuxDisponibles[0];
+}
+
+$dashboardUrl = 'dashboard.php?' . http_build_query([
+    'lieu' => $currentLieu,
+    'section' => 'consulter',
+]);
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -128,7 +139,7 @@ if (!isset($_SESSION['logged_in'])) {
 <?php $baseUrl = '..'; require __DIR__ . '/../partials/top_nav.php'; ?>
 <main class="visualisation-3d" role="main">
   <nav class="return-buttons" aria-label="Navigation retour">
-    <a href="consulter_stock.php" class="btn-retour">
+    <a href="<?= htmlspecialchars($dashboardUrl, ENT_QUOTES) ?>" class="btn-retour">
       ← Retour à la gestion des stocks
     </a>
   </nav>

--- a/app1.0/gestion_stock/dashboard.php
+++ b/app1.0/gestion_stock/dashboard.php
@@ -885,7 +885,7 @@ a.back-home:hover {
   </script>
 
 <div class="menu-actions" style="margin:20px 0; text-align:center;">
-    <a href="consultation_emplacement.php"
+    <a href="Consultation_emplacement.php?lieu=<?= urlencode($currentLieu) ?>&section=consulter"
        style="background:#007bff; color:white; padding:10px 20px;
               border-radius:8px; text-decoration:none; font-weight:bold;">
         🗂️ Voir les emplacements en 3D


### PR DESCRIPTION
## Summary
- pass the selected site when opening the 3D emplacement view
- update the 3D view return link so it leads back to the dashboard list instead of the admin-only edit page

## Testing
- php -l app1.0/gestion_stock/dashboard.php
- php -l app1.0/gestion_stock/Consultation_emplacement.php

------
https://chatgpt.com/codex/tasks/task_e_68dfd4538b28832a8497b6eb783d3f13