### PR TITLE
Align Ouled Saleh table spots with table length

### DIFF
--- a/app1.0/gestion_stock/Consultation_emplacement_ouled_saleh.php
+++ b/app1.0/gestion_stock/Consultation_emplacement_ouled_saleh.php
@@ -318,15 +318,15 @@ $dashboardUrl = 'dashboard.php?' . http_build_query([
       const labelIndex = index + 1;
 
       const topSpot = createSpot({
-        size: new THREE.Vector3(tableDepth * 0.9, 0.04, tableWidth / 3 * 0.9),
-        position: new THREE.Vector3(0, tableHeight + 0.05, offset),
+        size: new THREE.Vector3(tableWidth / 3 * 0.9, 0.04, tableDepth * 0.9),
+        position: new THREE.Vector3(offset, tableHeight + 0.05, 0),
         label: `A${labelIndex}`,
       });
       tableSpotGroup.add(topSpot);
 
       const bottomSpot = createSpot({
-        size: new THREE.Vector3(tableDepth * 0.9, 0.5, tableWidth / 3 * 0.9),
-        position: new THREE.Vector3(0, 0.25, offset),
+        size: new THREE.Vector3(tableWidth / 3 * 0.9, 0.5, tableDepth * 0.9),
+        position: new THREE.Vector3(offset, 0.25, 0),
         label: `B${labelIndex}`,
       });
       tableSpotGroup.add(bottomSpot);


### PR DESCRIPTION
## Summary
- orient the Ouled Saleh consultation table spot meshes along the table length so the labels follow the long side

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfe6f46554832aa66dbf38f778a6ce