### PR TITLE
Add step number badges to software browser flow

### DIFF
--- a/app1.0/assets/css/styles.css
+++ b/app1.0/assets/css/styles.css
@@ -456,6 +456,22 @@ main {
     margin: 0;
     font-size: 1.2rem;
     color: var(--primary-dark);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.browser-step .step-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: var(--primary-color);
+    color: #ffffff;
+    font-weight: 700;
+    flex-shrink: 0;
 }
 
 .equipment-choice {

--- a/app1.0/logiciels.php
+++ b/app1.0/logiciels.php
@@ -503,7 +503,7 @@ function toSearchIndex(array $values): string
             <?php else: ?>
                 <div class="software-browser">
                     <div class="browser-step">
-                        <h3>1. Choisissez une catégorie</h3>
+                        <h3><span class="step-number">1</span> Choisissez une catégorie</h3>
                         <div class="equipment-choice" role="group" aria-label="Choix de la catégorie du DM">
                             <?php foreach ($equipmentOptions as $equipment => $designations): ?>
                                 <button type="button" class="equipment-button" data-equipment-choice="<?= e($equipment); ?>">
@@ -514,7 +514,7 @@ function toSearchIndex(array $values): string
                     </div>
 
                     <div class="browser-step">
-                        <h3>2. Sélectionnez un DM</h3>
+                        <h3><span class="step-number">2</span> Sélectionnez un DM</h3>
                         <p class="muted" id="equipment-instructions">Choisissez une catégorie pour afficher les DM associés.</p>
                         <div class="designation-grid" id="designation-grid">
                             <?php foreach ($equipmentOptions as $equipment => $designations): ?>
@@ -530,7 +530,7 @@ function toSearchIndex(array $values): string
                     </div>
 
                     <div class="browser-step">
-                        <h3>3. Logiciels disponibles</h3>
+                        <h3><span class="step-number">3</span> Logiciels disponibles</h3>
                         <p class="muted" id="designation-instructions">Sélectionnez un DM pour afficher les logiciels correspondants.</p>
                         <div class="backup-filters hidden" id="software-filters">
                             <div class="filter-field">


### PR DESCRIPTION
## Summary
- restyle the software browser step headings so numbered badges lead each step
- add CSS for step-number badges to align the headings from the left

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfe82974dc832a960dceef2e6827b5