### PR TITLE
Adjust Ouled Saleh table spot labels

### DIFF
--- a/app1.0/gestion_stock/Consultation_emplacement_ouled_saleh.php
+++ b/app1.0/gestion_stock/Consultation_emplacement_ouled_saleh.php
@@ -314,8 +314,10 @@ $dashboardUrl = 'dashboard.php?' . http_build_query([
       tableWidth / 2 - (index + 0.5) * (tableWidth / 3)
     );
 
+    const labelOrder = [3, 2, 1];
+
     slotOffsets.forEach((offset, index) => {
-      const labelIndex = index + 1;
+      const labelIndex = labelOrder[index];
 
       const topSpot = createSpot({
         size: new THREE.Vector3(tableWidth / 3 * 0.9, 0.04, tableDepth * 0.9),


### PR DESCRIPTION
## Summary
- reverse the table slot label order so the Ouled Saleh 3D view shows A3/A2/A1 above B3/B2/B1 as requested

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6287c0824832a937e4c76e0c649df