### PR TITLE
Fix stock visualization return buttons

### DIFF
--- a/app1.0/gestion_stock/Consultation_emplacement.php
+++ b/app1.0/gestion_stock/Consultation_emplacement.php
@@ -11,7 +11,7 @@ if (!in_array($currentLieu, $lieuxDisponibles, true)) {
     $currentLieu = $lieuxDisponibles[0];
 }
 
-$dashboardUrl = 'dashboard.php?' . http_build_query([
+$gestionStockUrl = 'dashboard.php?' . http_build_query([
     'lieu' => $currentLieu,
     'section' => 'consulter',
 ]);
@@ -139,7 +139,7 @@ $dashboardUrl = 'dashboard.php?' . http_build_query([
 <?php $baseUrl = '..'; require __DIR__ . '/../partials/top_nav.php'; ?>
 <main class="visualisation-3d" role="main">
   <nav class="return-buttons" aria-label="Navigation retour">
-    <a href="<?= htmlspecialchars($dashboardUrl, ENT_QUOTES) ?>" class="btn-retour">
+    <a href="<?= htmlspecialchars($gestionStockUrl, ENT_QUOTES) ?>" class="btn-retour">
       ← Retour à la gestion des stocks
     </a>
   </nav>

--- a/app1.0/gestion_stock/Consultation_emplacement_ouled_saleh.php
+++ b/app1.0/gestion_stock/Consultation_emplacement_ouled_saleh.php
@@ -6,7 +6,7 @@ if (!isset($_SESSION['logged_in'])) {
 }
 
 $currentLieu = 'Ouled Saleh';
-$dashboardUrl = 'dashboard.php?' . http_build_query([
+$gestionStockUrl = 'dashboard.php?' . http_build_query([
     'lieu' => $currentLieu,
     'section' => $_GET['section'] ?? 'consulter',
 ]);
@@ -102,7 +102,7 @@ $dashboardUrl = 'dashboard.php?' . http_build_query([
 <body>
   <?php $baseUrl = '..'; require __DIR__ . '/../partials/top_nav.php'; ?>
   <nav class="return-buttons" aria-label="Navigation retour">
-    <a href="<?= htmlspecialchars($dashboardUrl, ENT_QUOTES) ?>" class="btn-retour">
+    <a href="<?= htmlspecialchars($gestionStockUrl, ENT_QUOTES) ?>" class="btn-retour">
       ← Retour à la gestion des stocks
     </a>
   </nav>


### PR DESCRIPTION
## Summary
- ensure the return buttons on both stock visualization pages link back to the stock dashboard rather than the main interface by using a dedicated URL variable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e62a0d56f8832a8397c32a3d83df0f